### PR TITLE
docs: fix example path

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ See [the tsdoc](./src/types.ts) for more advanced options
 
 ## Example
 
-See the [/example](./example).
+See the [/examples](./examples).
 
 Or the pre-configured Markdown template [Vitesse](https://github.com/antfu/vitesse).
 


### PR DESCRIPTION
fix: ./example => ./examples